### PR TITLE
Add/bing daily image plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -56,7 +56,7 @@
     "repositoryUrl": "https://github.com/schxar/music_plugin"
   },
   {
-    "id": "ikun11451.bing_daily_image_plugin",
+    "id": "ikun-11451.bing_daily_image_plugin",
     "repositoryUrl": "https://github.com/ikun11451/bing_daily_image_plugin"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -54,5 +54,9 @@
   {
     "id": "schxar.music_plugin",
     "repositoryUrl": "https://github.com/schxar/music_plugin"
+  },
+  {
+    "id": "ikun11451.bing_daily_image_plugin",
+    "repositoryUrl": "https://github.com/ikun11451/bing_daily_image_plugin"
   }
 ]


### PR DESCRIPTION
### 新增插件提交

**插件仓库 URL:https://github.com/ikun-11451/bing_daily_image_plugin**

---

### 核对清单 (Checklist)
我已确认：

阅读 CONTRIBUTING.md
仓库公开且包含 _manifest.json
许可证文件匹配
已正确更新 plugins.json

插件 URL：https://github.com/ikun-11451/bing_daily_image_plugin

## Sourcery 总结

新功能：
- 在 plugins.json 中注册 Bing 每日图片插件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Register the Bing Daily Image plugin in plugins.json

</details>